### PR TITLE
Updates Travis's Byond Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tgstation/byond:512.1463 as base
+FROM tgstation/byond:512.1478 as base
 
 FROM base as build_base
 


### PR DESCRIPTION
Updates Travis to use 512.1478 to prevent build errors. Needed for #23 to pass its checks.