### PR TITLE
Fixes overmap observers not being cleared.

### DIFF
--- a/nsv13/code/modules/overmap/camera.dm
+++ b/nsv13/code/modules/overmap/camera.dm
@@ -55,6 +55,7 @@
 	M.overmap_ship = null
 	M.cancel_camera()
 	M.remote_control = null
+	return TRUE
 
 /obj/structure/overmap/proc/CreateEye(mob/user)
 	if(!user.client)


### PR DESCRIPTION
## About The Pull Request
title, just adds a return TRUE at the end of stop_piloting.
The stop observing action expects stop_piloting to return a value that is true.

fixes #145 

## Changelog
:cl:
fix: Overmap "Stop Observing" action buttons and observer mobs now get removed when stopping observing.
/:cl: