### PR TITLE
Null Sword Fix

### DIFF
--- a/nsv13/game/custom_items.dm
+++ b/nsv13/game/custom_items.dm
@@ -6,8 +6,10 @@
 	item_state = "stunsword"
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_BULKY
-	force = 0
+	force = 10
 	on_stun_sound = 'nsv13/sound/effects/saberhit.ogg'
+	attack_verb = list("immolated", "slashed")
+	hitsound = 'sound/weapons/rapierhit.ogg'
 
 	on_icon_state = "stunsword_active"
 	off_icon_state = "stunsword"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fix for the initial null state of the stunsword.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes unexpected item behaviour.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed stunsword starting in a null state
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
